### PR TITLE
Add missing symbol in script. Separate storage into two files: chain …

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -37,7 +37,9 @@ If you have followed the instruction of installation on the root level, please s
 ## Use
 
 ### Results
-Returned results are saved under the `result.txt` file. Except for `register`, results returned from all the other commands are appended in that file. `register` will overwrite the file.
+Returned results are saved under two files: `chain.txt` and `result.txt` file. 
+- `result.txt` saves the result returned from current command. 
+- `chain.txt` appends all the results (in bytes32) since the last `register` command. `register` will overwrite the file.
 
 ### Commands
 > <> denotes required parameters, [] denotes optional parameters.

--- a/cli/src/modules/dumpHash.ts
+++ b/cli/src/modules/dumpHash.ts
@@ -49,7 +49,8 @@ export const dumpHash = async (
         {
             title: 'Save dumped hash to local result.txt',
             task: async () => {
-                await fs.appendFile('./result.txt', "\n"+hash, 'utf8');
+                await fs.writeFile('./result.txt', hash, 'utf8');
+                await fs.appendFile('./chain.txt', "\n"+hash, 'utf8');
             }
         }
     ]);

--- a/cli/src/modules/register.ts
+++ b/cli/src/modules/register.ts
@@ -49,14 +49,15 @@ export const register = async (devicePubKey: string, userPubKey: string, network
             }
         },
         {
-            title: 'Save to local result.txt',
+            title: 'Save to local',
             task: async (ctx: Listr.ListrContext) => {
+                await fs.writeFile('./chain.txt', ctx.uniqueId, 'utf8');
                 await fs.writeFile('./result.txt', ctx.uniqueId, 'utf8');
             }
         }
     ]);
 
     const ctx = await tasks.run();
-    console.log(`Device ${ctx.chip} and user ${ctx.user} are registered under ID ${ctx.uniqueId}. See transaction status at ${explorerTx(ctx.provider, ctx.hash)}`);
+    console.log(`Device ${ctx.chip} and user ${ctx.user} are registered under ID ${ctx.uniqueId}. ${!ctx.hash ? '': `See transaction status at ${explorerTx(ctx.provider, ctx.hash)}`}`);
     return ctx.uniqueId;
 }

--- a/cli/src/modules/startup.ts
+++ b/cli/src/modules/startup.ts
@@ -1,7 +1,7 @@
 import Listr from 'listr';
 import { promises as fs } from 'fs';
 import { Signer, Wallet } from "ethers";
-import { contract, provider, explorerBlock } from "../web3/web3";
+import { getData, contract, provider, explorerBlock } from "../web3/web3";
 
 export const startup = async (network: string | undefined, signer: Signer | undefined): Promise<[string, string]> => {
     const tasks = new Listr([
@@ -32,9 +32,17 @@ export const startup = async (network: string | undefined, signer: Signer | unde
             }
         },
         {
-            title: 'Save to local result.txt',
+            title: 'Compute hash 0',
             task: async (ctx: Listr.ListrContext) => {
-                await fs.appendFile('./result.txt', "\n"+ctx.blockHash, 'utf8');
+              const typedData0 = {isFirstBlock: true, previousHash: ctx.blockHash, data: ""};
+              ctx.hash0 = await getData(ctx.contract, typedData0);
+            }
+        },
+        {
+            title: 'Save to local',
+            task: async (ctx: Listr.ListrContext) => {
+                await fs.appendFile('./chain.txt', "\n"+ctx.blockHash, 'utf8');
+                await fs.writeFile('./result.txt', ctx.hash0, 'utf8');
             }
         }
     ]);

--- a/cli/src/modules/verify.ts
+++ b/cli/src/modules/verify.ts
@@ -1,4 +1,5 @@
 import Listr from 'listr';
+import { promises as fs } from 'fs';
 import { constants, Signer, Wallet } from "ethers";
 import { contract, provider } from "../web3/web3";
 
@@ -45,6 +46,12 @@ export const verify = async (
                     console.log(error)
                     task.skip(JSON.stringify(error));
                 }
+            }
+        },
+        {
+            title: 'Save to local',
+            task: async (ctx: Listr.ListrContext) => {
+                await fs.writeFile('./result.txt', ctx.result, 'utf8');
             }
         }
     ]);

--- a/on-chain/hardhat.config.ts
+++ b/on-chain/hardhat.config.ts
@@ -94,7 +94,7 @@ task('demo-compute-and-sign-hash', 'Computes a non-first block hash with given d
     const thridPartyAddress = await thirdParty.getAddress();
     const chip = new hre.ethers.utils.SigningKey(hre.ethers.Wallet.fromMnemonic((hre.network.config.accounts as any).mnemonic, `m/44'/60'/0'/0/${taskArgs.chip}`).privateKey);
     const user = new hre.ethers.utils.SigningKey(hre.ethers.Wallet.fromMnemonic((hre.network.config.accounts as any).mnemonic, `m/44'/60'/0'/0/${taskArgs.user}`).privateKey);
-    const hashes = (await fs.readFile('../cli/result.txt', "utf8")).split('\n');
+    const hashes = (await fs.readFile('../cli/chain.txt', "utf8")).split('\n');
     const prevHash = hashes[hashes.length-1];
     const typed = {isFirstBlock: taskArgs.first, previousHash: prevHash, data: taskArgs.first ? "" : taskArgs.data};
     const hash = await getDataLocalRpc(taskArgs.address, taskArgs.chain, typed);
@@ -116,7 +116,7 @@ task('demo-verify-hash', 'Outputs command for verifying a hash')
   .setAction(async (taskArgs, hre: HardhatRuntimeEnvironment) => {
     const [thirdParty] = await hre.ethers.getSigners();
     const thridPartyAddress = await thirdParty.getAddress();
-    const hashes = (await fs.readFile('../cli/result.txt', "utf8")).split('\n');
+    const hashes = (await fs.readFile('../cli/chain.txt', "utf8")).split('\n');
     const prevHash = hashes[taskArgs.index];
     console.log(taskArgs.data);
     const data = taskArgs.data ? `"${taskArgs.data}"` : `""`;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@hoprnet/hopr-collaboration",
   "private": true,
   "scripts": {
-    "install-all": "cd ./cli && yarn cd ../on-chain && yarn && cd ..",
+    "install-all": "cd ./cli && yarn && cd ../on-chain && yarn && cd ..",
     "env-all": "cp ./cli/.env.example ./cli/.env && cp ./on-chain/.env.example ./on-chain/.env",
     "build-all": "cd ./cli && yarn build"
   }


### PR DESCRIPTION
- Separate logs into two files: result (storage per command) and chain (all the result since the last `register`)
- Add missing `&&` in the root folder script